### PR TITLE
Does not assume influxdb is provisioned

### DIFF
--- a/influxdb/provider.go
+++ b/influxdb/provider.go
@@ -68,11 +68,6 @@ func configure(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 
-	_, _, err = conn.Ping()
-	if err != nil {
-		return nil, fmt.Errorf("error pinging server: %s", err)
-	}
-
 	return conn, nil
 }
 


### PR DESCRIPTION
We forked the provider to the `lsst-sqre` org and resolved this [this issue](https://github.com/terraform-providers/terraform-provider-influxdb/issues/9), otherwise, the provider would assume that InfluxDB is already provisioned which is not the case.

Hopefully the PR will be merged upstream soon and we can use the official provider instead.